### PR TITLE
Update xkablevif() function

### DIFF
--- a/R/idsDisplay.R
+++ b/R/idsDisplay.R
@@ -105,7 +105,8 @@ xkablesummary <- function(df, title="Table: Statistics summary.", digits = 4, po
 #' @export
 xkablevif <- function(model, title="VIFs of the model", digits = 3, pos="left", bso="striped", wide=TRUE) {
   vifs = table( names(model$coefficients)[2:length(model$coefficients)] ) # remove intercept to set column names
-  vifs[] = faraway::vif(model) # set the values
+  vif_res = faraway::vif(model) # calculate vifs
+  vifs[] = vif_res[order(names(vif_res))] # set the values after sorting by variable names
   if (wide) { vifs <- t(vifs) }
   xkabledply( vifs, title=title, digits = digits, pos=pos, bso=bso )
 }


### PR DESCRIPTION
xkablevif() was putting out different results from vif() when the regressors were not in alphabetical order. The table() function reordered the names of the coefficients to alphabetical order but the values that were being assigned to vifs object were still in the order they were input into lm(). I added one step to sort the vif results by the coefficient names before setting the values.